### PR TITLE
Enable links on home page blog cards

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,8 +4,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Calendar, Download, ExternalLink, FileText, FlaskConical, Users } from "lucide-react"
+import { getRecentBlogPosts } from "@/lib/blog"
 
-export default function HomePage() {
+export default async function HomePage() {
+  const posts = await getRecentBlogPosts(3)
   return (
     <div className="min-h-screen">
       {/* Hero Section */}
@@ -62,44 +64,28 @@ export default function HomePage() {
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-            {[
-              {
-                title: "Implementing Digital Lab Inventory Management",
-                date: "March 15, 2024",
-                excerpt:
-                  "How we reduced inventory errors by 85% through digital tracking systems and automated reorder protocols.",
-                image: "/placeholder.svg?height=200&width=300",
-              },
-              {
-                title: "Safety Protocol Updates for Biosafety Level 2 Labs",
-                date: "March 8, 2024",
-                excerpt:
-                  "Recent updates to BSL-2 safety protocols and their implementation in academic laboratory settings.",
-                image: "/placeholder.svg?height=200&width=300",
-              },
-              {
-                title: "Student Engagement in Microbiology Labs",
-                date: "February 28, 2024",
-                excerpt:
-                  "Innovative teaching methods that increased student participation and understanding in practical microbiology sessions.",
-                image: "/placeholder.svg?height=200&width=300",
-              },
-            ].map((post, index) => (
-              <Card key={index} className="hover:shadow-lg transition-shadow">
-                <div className="aspect-video relative overflow-hidden rounded-t-lg">
-                  <Image src={post.image || "/placeholder.svg"} alt={post.title} fill className="object-cover" />
-                </div>
-                <CardHeader>
-                  <div className="flex items-center text-sm text-slate-500 mb-2">
-                    <Calendar className="h-4 w-4 mr-1" />
-                    {post.date}
+            {posts.map((post) => (
+              <Link href={`/blog/${post.slug}`} key={post.id}>
+                <Card className="hover:shadow-lg transition-shadow">
+                  <div className="aspect-video relative overflow-hidden rounded-t-lg">
+                    <Image src={post.image || "/placeholder.svg"} alt={post.title} fill className="object-cover" />
                   </div>
-                  <CardTitle className="text-lg">{post.title}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription className="text-slate-600">{post.excerpt}</CardDescription>
-                </CardContent>
-              </Card>
+                  <CardHeader>
+                    <div className="flex items-center text-sm text-slate-500 mb-2">
+                      <Calendar className="h-4 w-4 mr-1" />
+                      {new Date(post.date).toLocaleDateString("en-US", {
+                        year: "numeric",
+                        month: "short",
+                        day: "numeric",
+                      })}
+                    </div>
+                    <CardTitle className="text-lg">{post.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <CardDescription className="text-slate-600">{post.excerpt}</CardDescription>
+                  </CardContent>
+                </Card>
+              </Link>
             ))}
           </div>
 


### PR DESCRIPTION
## Summary
- fetch recent blog posts in `app/page.tsx`
- render each post as a link to its blog page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541f1b586c8323877473780412be0e